### PR TITLE
feat(srelogin): allow custom username

### DIFF
--- a/files/bin/srelogin
+++ b/files/bin/srelogin
@@ -43,7 +43,11 @@ import requests_html
 import requests_kerberos
 
 DEFAULT_CLUSTER = os.environ.get('OCM_CLUSTERID')
-DEFAULT_EMAIL = getpass.getuser() + '@redhat.com'
+if 'OCM_USERNAME' in os.environ:
+    DEFAULT_EMAIL =  os.environ.get('OCM_USERNAME') + '@redhat.com'
+else:
+    DEFAULT_EMAIL = getpass.getuser() + '@redhat.com'
+
 DEFAULT_OC_COMMAND = shutil.which('oc')
 DEFAULT_OCM_COMMAND = shutil.which('ocm')
 


### PR DESCRIPTION
as the script can be run inside a container which it's login user isn't the tokens user.

this commit was not tested and was typed from the github GUI, so please approve with caution